### PR TITLE
Real Time Optimisation: Integrate with CO2 Signal API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 **.idea/**
 
 **.DS_Store**
+
+**.sqlite**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p align="center"><i>Run Docker containers on Airflow using green energy</i></p>
 </dl>
 
-## About
+## 📖 About
 
 **VertFlow is an [Airflow](https://airflow.apache.org/) operator for
 running [Cloud Run Jobs](https://cloud.google.com/run/docs/create-jobs) on Google Cloud Platform in green data
@@ -24,27 +24,30 @@ centre possible.
 > with [Cloud Composer 2](https://cloud.google.com/composer/docs/composer-2/composer-versioning-overview) to save even
 > more money and CO2.
 
-## How to install
+## 🔧 How to install
 
-`pip install VertFlow` on your Airflow instance.
+1. `pip install VertFlow` on your Airflow instance.
+2. Ensure your Airflow scheduler has outbound access to the public internet.
+3. Get a [free API Key for the CO2 Signal API](https://www.co2signal.com/).
 > ℹ️ If you're using Cloud Composer,
 > follow [these instructions](https://cloud.google.com/composer/docs/how-to/using/installing-python-dependencies#install-package)
 > to install VertFlow from PyPi.
 
-## How to use
+>️ ℹ️ If you're using Cloud Composer with Private IP,
+> follow [these instructions](https://cloud.google.com/composer/docs/concepts/private-ip#public_internet_access_for_your_workflows)
+> to set up internet access.
+
+## 🖱 How to use
 
 Use the `VertFlowOperator` to instantiate a task in your DAG.
 Provide:
 
-1. The address of the Docker image to run.
-2. A runtime specification, e.g. timeout and memory limits.
-3. A set of allowed regions to run the job in, based on latency, data governance and other considerations. VertFlow
-   picks
-   the greenest one.
+* The address of the Docker image to run.
+* A runtime specification, e.g. timeout and memory limits.
+* A set of allowed regions to run the job in, based on latency, data governance and other considerations. VertFlow
+   picks the greenest one.
 
 ```python
-import datetime as dt
-
 from VertFlow.operator import VertFlowOperator
 from airflow import DAG
 
@@ -60,22 +63,21 @@ with DAG(
         command="echo",
         arguments=["Hello World"],
         service_account_email_address="my-service-account@embroidered-elephant-739.iam.gserviceaccount.com",
-        start_date=dt.datetime(2022, 6, 20),
-        task_id="test_vertflow_task"
+        co2_signal_api_key = "5bbWXo9PQv3outh45E4fsLHwgsXvf1Z"
+        ...
     )
 ```
 
-## Limitations
-* There is no test coverage on this library as yet. Tests will follow.
+## 🤷 Limitations
 * Cloud Run Jobs is not yet Generally Available. Production use is not advised. It also has a series of limitations,
   e.g. tasks can run for no longer than 1 hour.
 * The container running the Cloud Run Job cannot (yet) access resources on a VPC.
 * VertFlow (currently) assumes no emissions from transmitting data between regions. These may infact be non-trivial if
   storage and
   compute are far from each other. Charges may also be incurred in this scenario.
-* VertFlow uses the [duck curve](https://en.wikipedia.org/wiki/Duck_curve) of the [UK](https://carbonintensity.org.uk/)
-  to add daily shape to [Google's CFE% figures per region](https://cloud.google.com/sustainability/region-carbon#data).
-  This is a placeholder riddled with tenuous assumptions, pending robust real-time data.
 
-## How to contribute
+## 🔌🗺 Shout out to Electricity Maps
+VertFlow works thanks to real-time global carbon intensity data, gifted to the world by [Electricity Maps](https://app.electricitymaps.com/map).
+
+## 🤝 How to contribute
 Found a bug or fancy resolving one of the limitations? We welcome Pull Requests!

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup
 
 setup(
     name="VertFlow",
-    version="0.0.3",
+    version="0.1.0",
     description="Apache Airflow operator for running Google Cloud Run Jobs using green energy",
     long_description=(Path(__file__).parent / "README.md").read_text(),
     long_description_content_type="text/markdown",
@@ -28,9 +28,11 @@ setup(
     author_email="trading.dl@ovoenergy.com",
     packages=["VertFlow"],
     package_dir={"VertFlow": "src"},
-    include_package_data=True,
-    package_data={"VertFlow": ["data/*"]},
     python_requires=">=3.7",
-    install_requires=["google-api-python-client==2.51.0"],
+    install_requires=[
+        "google-api-python-client==2.51.0",
+        "requests-cache==0.9.5",
+        "geocoder==1.38.1",
+    ],
     license="Apache 2.0",
 )

--- a/src/cloud_run.py
+++ b/src/cloud_run.py
@@ -23,7 +23,7 @@ from google.api_core.client_options import ClientOptions
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from src.utils import intersection_equal
+from VertFlow.utils import intersection_equal
 
 
 def wait_until(  # type: ignore
@@ -97,6 +97,7 @@ class CloudRunJob:
                 name=self.job_address
             ).execute()
         wait_until(lambda: self.specification is None, 60)
+        self.__execution_id = None
 
     def create(
         self,
@@ -239,13 +240,15 @@ class CloudRunJob:
         )
 
         logging.info(
-            f"https://console.cloud.google.com/run/jobs/executions/details/{self.region}/{self.__execution_id}"
+            f"Cloud Run Job execution started. View execution logs at: "
+            f"https://console.cloud.google.com/run/jobs/executions/details/{self.region}/{execution['metadata']['name']}"
             f"/tasks?project={self.project_id}"
         )
         if wait:
+            sleep(5)
             wait_until(
                 lambda: self.__execution_completed() in ("True", "False"),
-                self.__run_timeout_seconds * (self.__max_retries + 1),
+                self.__run_timeout_seconds * (self.__max_retries + 1) + 10,
             )
 
     @property

--- a/src/data.py
+++ b/src/data.py
@@ -29,29 +29,27 @@ def half_hour_block(at: time) -> int:
 
 class CarbonIntensityData:
     def __init__(self) -> None:
-        self.data = list(
-            csv.DictReader(
-                codecs.getreader("utf-8")(resource_stream(__name__, "data/data.csv"))
-            )
-        )
+        data_csv_resource = resource_stream(__name__, "data/data.csv")
+        self.__data = list(csv.DictReader(codecs.getreader("utf-8")(data_csv_resource)))
+        data_csv_resource.close()
 
     def greenest_region(
-        self, candidate_regions: Optional[Sequence[str]], at_time: time
+        self, at: time, candidate_regions: Optional[Sequence[str]] = None
     ) -> str:
         """
         Return the Google Cloud region with the lowest carbon intensity at at_time.
         :param candidate_regions: A sequence of regions from which to select the greenest, or None to select from all
         regions.
-        :param at_time: The time at which to measure the carbon intensity of the regions.
+        :param at: The time at which to measure the carbon intensity of the regions.
         :return:
         """
 
         return min(
             [
                 item
-                for item in self.data
+                for item in self.__data
                 if (candidate_regions is None or item["Region"] in candidate_regions)
-                and int(item["Block"]) == half_hour_block(at_time)
+                and int(item["Block"]) == half_hour_block(at)
             ],
             key=lambda x: float(x["Intensity_gCO2_kWh"]),
         )["Region"]

--- a/src/data.py
+++ b/src/data.py
@@ -13,43 +13,158 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-import codecs
-import csv
-from datetime import time
-from math import floor
+import logging
+from datetime import timedelta
+from json import loads
+from time import sleep
 from typing import Sequence, Optional
 
-from pkg_resources import resource_stream
+import requests_cache
+from geocoder import ip, osm, distance
+from googleapiclient.discovery import build
 
 
-def half_hour_block(at: time) -> int:
-    return at.hour * 2 + floor(at.minute / 30)
-
-
-class CarbonIntensityData:
-    def __init__(self) -> None:
-        data_csv_resource = resource_stream(__name__, "data/data.csv")
-        self.__data = list(csv.DictReader(codecs.getreader("utf-8")(data_csv_resource)))
-        data_csv_resource.close()
-
-    def greenest_region(
-        self, at: time, candidate_regions: Optional[Sequence[str]] = None
-    ) -> str:
+class CloudRunRegions:
+    def __init__(self, project_id: str, co2_signal_api_key: str) -> None:
         """
-        Return the Google Cloud region with the lowest carbon intensity at at_time.
-        :param candidate_regions: A sequence of regions from which to select the greenest, or None to select from all
+        Location and carbon intensity data for regions supported by Google Cloud Run.
+        :param project_id: The GCP project to connect to.
+        :param co2_signal_api_key: The auth token for the CO2 Signal API from which to obtain carbon intensity data.
+        """
+        self.project_id = project_id
+        self.co2_signal_api_key = co2_signal_api_key
+
+        self.__all = self.__get_all_regions()
+
+    def __get_all_regions(self) -> list[dict[str, str | float]]:
+        client = build("run", "v1")
+        raw = (
+            client.projects()
+            .locations()
+            .list(name=f"projects/{self.project_id}")
+            .execute()["locations"]
+        )
+
+        all_regions: list[dict[str, str | float]] = []
+        for region in raw:
+            try:
+                geojson = osm(region["displayName"]).geojson["features"][0][
+                    "properties"
+                ]
+                all_regions.append(
+                    {
+                        "id": str(region["locationId"]),
+                        "name": str(region["displayName"]),
+                        "lat": float(geojson["lat"]),
+                        "lon": float(geojson["lng"]),
+                    }
+                )
+            except IndexError:  # Isolated to a single location. Other types should throw loudly.
+                logging.warning(
+                    f"Could not get geolocation data for region {region['locationId']}"
+                )
+
+        return all_regions
+
+    @property
+    def closest(self) -> dict[str, str | float | int]:
+        """
+        Return the Google Cloud region closest to this machine.
+        :return: A dictionary of data about the closest region.
+        """
+        geolocation = ip("me").latlng
+
+        here = dict()
+        here["lat"], here["lon"] = geolocation[0], geolocation[1]
+
+        distances_from_here = [
+            region
+            | {
+                "distance_from_current_location": int(
+                    distance((here["lat"], here["lon"]), (region["lat"], region["lon"]))
+                )
+            }
+            for region in self.__all
+        ]
+
+        closest = min(
+            distances_from_here, key=lambda x: x["distance_from_current_location"]
+        )
+
+        return closest | {
+            "carbon_intensity": self.__carbon_intensity(str(closest["id"]))
+        }
+
+    def greenest(
+            self, candidate_regions: Optional[Sequence[str]] = None
+    ) -> dict[str, str | float | int]:
+        """
+        Return the Google Cloud region with the lowest carbon intensity now.
+        :param candidate_regions: A sequence of region IDs from which to select the greenest, or None to select from all
         regions.
-        :param at: The time at which to measure the carbon intensity of the regions.
-        :return:
+        :return: A dictionary of data about the greenest region.
         """
+
+        if candidate_regions:
+            assert set(candidate_regions).issubset(
+                {region["id"] for region in self.__all}
+            ), f"Invalid region(s) provided. Allowed Cloud Run regions: {self.__all}"
+            regions = [
+                region for region in self.__all if region["id"] in candidate_regions
+            ]
+
+        else:
+            regions = self.__all
+
+        carbon_intensity_for_candidate_regions: list[dict[str, str | float | int]] = []
+
+        for region in regions:
+            try:
+                carbon_intensity_for_candidate_regions.append(
+                    region
+                    | {"carbon_intensity": self.__carbon_intensity(str(region["id"]))}
+                )
+            except LookupError:  # Skip over errors for individual regions.
+                logging.warning(
+                    f"Could not get carbon intensity data for region {region['id']}, so it was skipped."
+                )
+
+        if (
+                carbon_intensity_for_candidate_regions == []
+        ):  # If all regions failed, throw now.
+            raise LookupError(f"Could not get carbon intensity data for any region.")
 
         return min(
-            [
-                item
-                for item in self.__data
-                if (candidate_regions is None or item["Region"] in candidate_regions)
-                and int(item["Block"]) == half_hour_block(at)
-            ],
-            key=lambda x: float(x["Intensity_gCO2_kWh"]),
-        )["Region"]
+            carbon_intensity_for_candidate_regions, key=lambda x: x["carbon_intensity"]
+        )
+
+    def __carbon_intensity(self, region: str) -> int:
+        """
+        Return the carbon intensity of a Google Cloud Region with a given ID, using data from CO2 Signal API.
+        Uses locally-cached API data where possible, to prevent hitting rate limits.
+        :param region: The ID of the region.
+        :return: The carbon intensity (in gCO2eq/kWh)
+        """
+        sleep(1)  # To avoid API rate limits.
+        region_obj = [r for r in self.__all if region == r["id"]][0]
+
+        try:
+            session = requests_cache.CachedSession("co2_signal_cache", expire_after=timedelta(hours=1))
+            request = session.get(
+                f"https://api.co2signal.com/v1/latest?lon={region_obj['lon']}&lat={region_obj['lat']}",
+                headers={"auth-token": self.co2_signal_api_key},
+            )
+            assert (
+                    request.status_code == 200
+            ), f"Got bad response code {request.status_code} from CO2 Signal API."
+        except Exception as e:
+            raise ConnectionError(
+                f"Failed to get carbon intensity data from CO2 Signal. Check your internet connection and API key.\n{repr(e)}"
+            )
+        response = loads(request.content)
+
+        if "carbonIntensity" not in response["data"].keys():
+            raise LookupError(
+                f"Carbon intensity data not available from CO2 Signal for region {region}."
+            )
+        return int(response["data"]["carbonIntensity"])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,35 +1,36 @@
-from typing import Optional
+from typing import Optional, Any
 
 
-def intersection_equal(dict_a: Optional[dict], dict_b: Optional[dict]) -> bool:
+def intersection_equal(a: Optional[Any], b: Optional[Any]) -> bool:
     """
-    Determines mutual keys between two dictionaries.
-    Returns True if the values of those mutual keys are equal.
-    Recursively crawls through any nested dictionaries and lists of dictionaries.
-    :param dict_a: A dictionary, potentially containing nested (lists of) dictionaries.
-    :param dict_b: A dictionary, potentially containing nested (lists of) dictionaries.
-    :return: True, if the values of all mututal keys in the dictionary tree are equal.
+    Determines mutual items (dictionary keys or list indices) in two iterables.
+    Returns True if the values of those mutual items are equal.
+    Recursively crawls through any nested iterables.
+    If non-iterables are provided, a simple equality check is run on them both.
+    :param a: A dictionary, list or non-iterable Any-type.
+    :param b: A dictionary, list or non-iterable Any-type.
+    :return: True, if the values of all mutual items are equal.
     """
 
-    # Shortcut
-    if dict_a == dict_b:  # Either both None or both not-None and identical.
+    # Shortcuts
+    if a == b:  # Either both None or both not-None and identical.
         return True
-
-    if not dict_a or not dict_b:  # Exactly one is None.
+    if not a or not b:  # Exactly one is None.
         return False
+    if not (type(a) == type(b) == dict) and not (type(a) == type(b) == list):
+        return bool(a == b)
 
     equal = True
-    for x in dict_a:
-        if x in dict_b:
-            if isinstance(dict_a[x], dict) and isinstance(dict_b[x], dict):
-                equal = equal and intersection_equal(dict_a[x], dict_b[x])
-            elif isinstance(dict_a[x], list) and isinstance(dict_b[x], list):
+
+    for x in a:
+        if x in b:
+            if isinstance(a[x], dict) and isinstance(b[x], dict):
+                equal = equal and intersection_equal(a[x], b[x])
+            elif isinstance(a[x], list) and isinstance(b[x], list):
                 k = 0
-                for v in dict_a[x]:
-                    equal = equal and intersection_equal(
-                        dict_a[x][k], dict_b[x][k]
-                    )  # This will only work if both of them are lists of dicts of equal length. Need to genercise to work with any lists of arbitary length with any inner type.
+                for v in a[x]:
+                    equal = equal and intersection_equal(a[x][k], b[x][k])
                     k += 1
             else:
-                equal = equal and dict_a[x] == dict_b[x]
+                equal = equal and intersection_equal(a[x], b[x])
     return equal

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+
+def intersection_equal(dict_a: Optional[dict], dict_b: Optional[dict]) -> bool:
+    """
+    Determines mutual keys between two dictionaries.
+    Returns True if the values of those mutual keys are equal.
+    Recursively crawls through any nested dictionaries and lists of dictionaries.
+    :param dict_a: A dictionary, potentially containing nested (lists of) dictionaries.
+    :param dict_b: A dictionary, potentially containing nested (lists of) dictionaries.
+    :return: True, if the values of all mututal keys in the dictionary tree are equal.
+    """
+
+    # Shortcut
+    if dict_a == dict_b:  # Either both None or both not-None and identical.
+        return True
+
+    if not dict_a or not dict_b:  # Exactly one is None.
+        return False
+
+    equal = True
+    for x in dict_a:
+        if x in dict_b:
+            if isinstance(dict_a[x], dict) and isinstance(dict_b[x], dict):
+                equal = equal and intersection_equal(dict_a[x], dict_b[x])
+            elif isinstance(dict_a[x], list) and isinstance(dict_b[x], list):
+                k = 0
+                for v in dict_a[x]:
+                    equal = equal and intersection_equal(
+                        dict_a[x][k], dict_b[x][k]
+                    )  # This will only work if both of them are lists of dicts of equal length. Need to genercise to work with any lists of arbitary length with any inner type.
+                    k += 1
+            else:
+                equal = equal and dict_a[x] == dict_b[x]
+    return equal

--- a/test/cloud_run.py
+++ b/test/cloud_run.py
@@ -1,0 +1,177 @@
+from time import time, sleep
+from typing import Optional
+from unittest import TestCase
+
+from src.cloud_run import CloudRunJob, wait_until
+from src.utils import intersection_equal
+
+
+def create_quick_test_job(job: CloudRunJob, command: str, args: list[str]) -> None:
+    job.create(
+        annotations={},
+        image_address="us-docker.pkg.dev/cloudrun/container/job:latest",
+        command=command,
+        args=args,
+        environment_variables={},
+        working_directory="/",
+        port_number=8080,
+        max_retries=0,
+        timeout_seconds=30,
+        initialisation_timeout_seconds=120,
+        service_account_email_address="empty-no-permissions@trading-nonprod.iam.gserviceaccount.com",
+        cpu_limit=1,
+        memory_limit="512Mi",
+    )
+
+
+class TestWaitUntil(TestCase):
+    def setUp(self) -> None:
+        self.number_of_calls_until_returns_true = 3
+        self.call_count = 0
+        self.wait_interval_seconds = 5
+
+    def condition_to_wait_for(self) -> bool:
+        if self.call_count < self.number_of_calls_until_returns_true:
+            self.call_count += 1
+            return False
+        else:
+            return True
+
+    def test_wait_until_blocks_until_condition_returns_true(self) -> None:
+
+        time_before_wait = time()
+
+        # Condition will return true after 15 seconds.
+        wait_until(self.condition_to_wait_for, 20, self.wait_interval_seconds)
+
+        # Validate that wait_until exits cleanly after c. 15 seconds.
+        self.assertTrue(
+            self.number_of_calls_until_returns_true * self.wait_interval_seconds
+            < time() - time_before_wait
+            <= self.number_of_calls_until_returns_true * self.wait_interval_seconds + 1
+        )
+
+    def test_wait_throws_if_timeout_is_reached_before_condition_returns_true(
+        self,
+    ) -> None:
+
+        time_before_wait = time()
+        timeout_seconds = 5
+        exception_thrown: Optional[Exception] = None
+
+        try:
+            wait_until(
+                self.condition_to_wait_for, timeout_seconds, self.wait_interval_seconds
+            )
+        except Exception as e:
+            exception_thrown = e
+
+        time_after_wait = time()
+
+        # Validate that wait_until exits after timeout
+        self.assertTrue(
+            timeout_seconds < time_after_wait - time_before_wait <= timeout_seconds + 1
+        )
+
+        # Validate that wait_until throws a TimeoutError
+        self.assertIsInstance(exception_thrown, TimeoutError)
+
+
+class TestCloudRunJobEndToEnd(TestCase):
+    def setUp(self) -> None:
+        # Instantiate a brand new Cloud Run job.
+        self.job = CloudRunJob(
+            "europe-west2", "trading-nonprod", f"vertflow-e2e-test-{int(time())}"
+        )
+
+    def tearDown(self) -> None:
+        self.job.delete()
+
+    def test_end_to_end(self) -> None:
+        """
+        Conduct an end-to-end test of spinning up a Cloud Run Job, creating a series of executions, and deleting it.
+        """
+
+        # Validate that the job has an empty spec, as it does not exist yet.
+        self.assertIsNone(self.job.specification)
+
+        # Create a new Job with a spec prescribed locally.
+        create_quick_test_job(self.job, "echo", ["Hello World"])
+
+        # Validate that the spec is non-empty, i.e. the job was created successfully.
+        spec_from_first_creation = self.job.specification
+        self.assertIsNotNone(self.job.specification)
+
+        with self.assertLogs() as captured_logs:
+            # Create a new Job with an identical specification.
+            create_quick_test_job(self.job, "echo", ["Hello World"])
+
+            # Validate that no change is made.
+            expected_log_message = "A Cloud Run Job already exists with an identical specification. No action taken."
+        self.assertEqual(len(captured_logs.records), 1)
+        self.assertEqual(captured_logs.records[0].getMessage(), expected_log_message)
+
+        # Validate that spec from the second run is identical to the first.
+        self.assertTrue(
+            intersection_equal(spec_from_first_creation, self.job.specification)
+        )
+
+        # Create a new Job that is different to the first.
+        create_quick_test_job(self.job, "echo", ["Hello World 2"])
+
+        # Validate that the spec is different, i.e. the change was successfully applied.
+        self.assertFalse(
+            intersection_equal(spec_from_first_creation, self.job.specification)
+        )
+
+        with self.assertLogs() as captured_logs:
+            # Attempt to cancel the job execution.
+            self.job.cancel()
+
+            # Validate that warning that there is nothing to cancel is presented.
+            expected_log_message = "No job execution to cancel."
+            self.assertEqual(len(captured_logs.records), 1)
+            self.assertEqual(
+                captured_logs.records[0].getMessage(), expected_log_message
+            )
+
+        # Validate that details relating to execution are empty.
+        self.assertIsNone(self.job.execution)
+        self.assertIsNone(self.job.execution_log_uri)
+        self.assertFalse(self.job.executed_successfully)
+
+        # Run the job
+        time_before_run = time()
+        self.job.run()
+        execution_duration = time() - time_before_run
+
+        # Validate that the client waited for the job to complete.
+        self.assertTrue(execution_duration > 10)
+
+        # Validate that details relating to execution are nonempty.
+        self.assertIsNotNone(self.job.execution)
+        self.assertIsNotNone(self.job.execution_log_uri)
+        self.assertTrue(self.job.executed_successfully)
+
+        # Run the job again, then cancel it.
+        self.job.run()
+        sleep(10)
+        self.job.cancel()
+
+        # Validate that details relating to execution are empty.
+        self.assertIsNone(self.job.execution)
+        self.assertIsNone(self.job.execution_log_uri)
+        self.assertFalse(self.job.executed_successfully)
+
+        # Create and run a new job with a spec that will fail when executed.
+        create_quick_test_job(self.job, "exit", ["1"])
+        self.job.run()
+
+        # Validate that the run was not successful.
+        self.assertFalse(self.job.executed_successfully)
+
+        # Delete the job
+        self.job.delete()
+
+        # Validate that the spec is empty, i.e. the job was deleted.
+        self.assertIsNone(self.job.specification)

--- a/test/data.py
+++ b/test/data.py
@@ -1,0 +1,21 @@
+from datetime import time
+from unittest import TestCase
+
+from src.data import half_hour_block, CarbonIntensityData
+
+
+class TestData(TestCase):
+    def setUp(self) -> None:
+        self.data = CarbonIntensityData()
+
+    def test_half_hour_block(self) -> None:
+        self.assertEqual(half_hour_block(time(0, 0, 0)), 0)
+        self.assertEqual(half_hour_block(time(23, 45, 0)), 47)
+        self.assertEqual(half_hour_block(time(12, 45, 38)), 25)
+
+    def test_greenest_region(self) -> None:
+        self.assertEqual(self.data.greenest_region(time(0, 0, 0)), "europe-north1")
+        self.assertEqual(
+            self.data.greenest_region(time(0, 0, 0), ["us-east1", "us-west1"]),
+            "us-west1",
+        )

--- a/test/data.py
+++ b/test/data.py
@@ -1,21 +1,19 @@
-from datetime import time
 from unittest import TestCase
-
-from src.data import half_hour_block, CarbonIntensityData
 
 
 class TestData(TestCase):
     def setUp(self) -> None:
-        self.data = CarbonIntensityData()
+        pass
 
-    def test_half_hour_block(self) -> None:
-        self.assertEqual(half_hour_block(time(0, 0, 0)), 0)
-        self.assertEqual(half_hour_block(time(23, 45, 0)), 47)
-        self.assertEqual(half_hour_block(time(12, 45, 38)), 25)
-
-    def test_greenest_region(self) -> None:
-        self.assertEqual(self.data.greenest_region(time(0, 0, 0)), "europe-north1")
-        self.assertEqual(
-            self.data.greenest_region(time(0, 0, 0), ["us-east1", "us-west1"]),
-            "us-west1",
-        )
+    """
+    TESTS TO ADD
+    Instantiation.
+    Closest, if we freeze IP.
+    Greenest:
+    -Bad region throws
+    -No regions
+    -Some good regions
+    -Warning if single region can't lookup
+    -Throws if all regions can't lookup.
+    -Loud connection error if no internet, rate limit, bad/no key.
+    """

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,194 @@
+from unittest import TestCase
+
+from src.utils import intersection_equal
+
+
+class TestIntersectionEqual(TestCase):
+    def setUp(self) -> None:
+        self.spec_1_sent = {
+            "apiVersion": "run.googleapis.com/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": "vertflow-e2e-test-1657479711",
+                "annotations": {
+                    "run.googleapis.com/launch-stage": "BETA",
+                    "run.googleapis.com/execution-environment": "gen2",
+                },
+            },
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "run.googleapis.com/launch-stage": "BETA",
+                            "run.googleapis.com/execution-environment": "gen2",
+                        }
+                    },
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": "us-docker.pkg.dev/cloudrun/container/job:latest",
+                                        "command": ["echo"],
+                                        "args": ["Hello World"],
+                                        "env": [],
+                                        "resources": {
+                                            "limits": {"cpu": "1", "memory": "512Mi"}
+                                        },
+                                        "workingDir": "/",
+                                        "ports": [{"containerPort": 8080}],
+                                    }
+                                ],
+                                "maxRetries": 0,
+                                "timeoutSeconds": "30",
+                                "serviceAccountName": "empty-no-permissions@trading-nonprod.iam.gserviceaccount.com",
+                            }
+                        }
+                    },
+                }
+            },
+        }
+        self.spec_1_received = {
+            "apiVersion": "run.googleapis.com/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": "vertflow-e2e-test-1657479711",
+                "namespace": "714098496902",
+                "selfLink": "/apis/run.googleapis.com/v1/namespaces/714098496902/jobs/vertflow-e2e-test-1657479711",
+                "uid": "eb00160c-13dc-4c70-a5dc-850abdec5a1b",
+                "resourceVersion": "AAXjeBMXSfE",
+                "generation": 1,
+                "creationTimestamp": "2022-07-10T19:02:18.734980Z",
+                "labels": {"cloud.googleapis.com/location": "europe-west2"},
+                "annotations": {
+                    "run.googleapis.com/lastModifier": "jack.lockyer-stevens@ovo.com",
+                    "run.googleapis.com/creator": "jack.lockyer-stevens@ovo.com",
+                    "run.googleapis.com/execution-environment": "gen2",
+                    "run.googleapis.com/launch-stage": "BETA",
+                },
+            },
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "run.googleapis.com/launch-stage": "BETA",
+                            "run.googleapis.com/execution-environment": "gen2",
+                        }
+                    },
+                    "spec": {
+                        "taskCount": 1,
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": "us-docker.pkg.dev/cloudrun/container/job:latest",
+                                        "command": ["echo"],
+                                        "args": ["Hello World"],
+                                        "workingDir": "/",
+                                        "ports": [{"containerPort": 8080}],
+                                        "resources": {
+                                            "limits": {"cpu": "1", "memory": "512Mi"}
+                                        },
+                                    }
+                                ],
+                                "maxRetries": 0,
+                                "timeoutSeconds": "30",
+                                "serviceAccountName": "empty-no-permissions@trading-nonprod.iam.gserviceaccount.com",
+                            }
+                        },
+                    },
+                }
+            },
+            "status": {
+                "observedGeneration": 1,
+                "conditions": [
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastTransitionTime": "2022-07-10T19:02:19.427313Z",
+                    }
+                ],
+            },
+        }
+
+        self.spec_2_sent = {
+            "apiVersion": "run.googleapis.com/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": "vertflow-e2e-test-different-name",
+                "annotations": {
+                    "run.googleapis.com/launch-stage": "BETA",
+                    "run.googleapis.com/execution-environment": "gen2",
+                },
+            },
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "run.googleapis.com/launch-stage": "BETA",
+                            "run.googleapis.com/execution-environment": "gen2",
+                        }
+                    },
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": "us-docker.pkg.dev/cloudrun/container/job:latest",
+                                        "command": ["echo"],
+                                        "args": ["Hello World - Different Command"],
+                                        "env": [],
+                                        "resources": {
+                                            "limits": {"cpu": "1", "memory": "512Mi"}
+                                        },
+                                        "workingDir": "/",
+                                        "ports": [{"containerPort": 8080}],
+                                    }
+                                ],
+                                "maxRetries": 0,
+                                "timeoutSeconds": "30",
+                                "serviceAccountName": "empty-no-permissions@trading-nonprod.iam.gserviceaccount.com",
+                            }
+                        }
+                    },
+                }
+            },
+        }
+
+    def test_basic(self) -> None:
+        self.assertTrue(intersection_equal({}, {}))
+        self.assertTrue(
+            intersection_equal(
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 3},
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 3},
+            )
+        )
+        self.assertFalse(
+            intersection_equal(
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 3},
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 4},
+            )
+        )
+        self.assertTrue(
+            intersection_equal(
+                {"a": {"aa": 11}, "bb": 22, "cc": 33},
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 3},
+            )
+        )
+        self.assertFalse(
+            intersection_equal(
+                {"a": {"aa": 44}, "b": 2, "c": 3},
+                {"a": {"aa": 11, "bb": 22}, "b": 2, "c": 3},
+            )
+        )
+        self.assertTrue(
+            intersection_equal(
+                {"a": {"aa": 11}, "b": 2, "c": 3}, {"a": {"bb": 22}, "b": 2, "c": 3}
+            )
+        )
+
+    def test_spec_sent_and_received_are_equal(self) -> None:
+        self.assertTrue(intersection_equal(self.spec_1_sent, self.spec_1_received))
+
+    def test_spec_sent_and_different_spec_received_are_not_equal(self) -> None:
+        self.assertFalse(intersection_equal(self.spec_2_sent, self.spec_1_received))


### PR DESCRIPTION
- Integrate with CO2 Signal API to get real-time carbon intensity data. Add arg for API key and update docs.
- Cache API calls to prevent rate limiting. Auto-fallback to one of the allowed regions if any API calls fail.
- Display saving between greenest and closest region in the logs.
- Bump to minor version 0.1.0
- Fix bug with waiting for a task to complete remotely.
- Make comparison of two job specifications more robust. Improves performance as it allows VertFlow to skip creating a Job if one already exists with the same spec.
- Fix bug where wrong link to Cloud Run console appears in the logs.